### PR TITLE
fix(security): updated aws-sdk version in development dependencies

### DIFF
--- a/source/changeset-validator/package.json
+++ b/source/changeset-validator/package.json
@@ -10,7 +10,7 @@
   "author": "aws-solutions-builders",
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "jest": "^26.6.3"
   },
   "dependencies": {

--- a/source/drift-detection/package.json
+++ b/source/drift-detection/package.json
@@ -10,7 +10,7 @@
   "author": "aws-solutions-builders",
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "jest": "^26.6.3"
   }
 }

--- a/source/rollback-change/package.json
+++ b/source/rollback-change/package.json
@@ -13,7 +13,7 @@
     "adm-zip": "~0.4.16"
   },
   "devDependencies": {
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "jest": "^26.6.3"
   }
 }

--- a/source/secondary-bucket-creator/package.json
+++ b/source/secondary-bucket-creator/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "aws-lambda": "^1.0.5",
-    "aws-sdk": "^2.606.0",
+    "aws-sdk": "2.1001.0",
     "@types/node": "^13.1.8",
     "@types/jest": "^24.9.0",
     "aws-sdk-mock": "^5.0.0",

--- a/source/stage-artifact-creator/package.json
+++ b/source/stage-artifact-creator/package.json
@@ -13,7 +13,7 @@
     "adm-zip": "~0.4.16"
   },
   "devDependencies": {
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "jest": "^26.6.3"
   }
 }

--- a/source/stage-artifact-putter/package.json
+++ b/source/stage-artifact-putter/package.json
@@ -10,7 +10,7 @@
   "author": "aws-solutions-builders",
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "jest": "^26.6.3"
   }
 }

--- a/source/uuid-generator/package.json
+++ b/source/uuid-generator/package.json
@@ -14,7 +14,7 @@
     "@types/jest": "26.0.3",
     "@types/node": "14.0.14",
     "@types/uuid": "8.0.0",
-    "aws-sdk": "2.631.0",
+    "aws-sdk": "2.1001.0",
     "axios-mock-adapter": "1.18.1",
     "jest": "^26.6.3",
     "ts-jest": "26.1.1",


### PR DESCRIPTION
*Description of changes:*
This is to fix security vulnerabilities on `aws-sdk`.
All `aws-sdk` in `devDependencies` are going to be updated to the latest `aws-sdk` supported by AWS Lambda Node.js 12.x runtime: `2.1001.0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
